### PR TITLE
Issue_39_USED_RESOURCES_PAGE_freepik.com_section

### DIFF
--- a/locators/used_resources_page_locators.py
+++ b/locators/used_resources_page_locators.py
@@ -6,3 +6,4 @@ class UsedResourcesPageLocators:
     PAGE_TEXT = (By.XPATH, "//section/p")
     LINKS_SECTION = (By.XPATH, "//section/ul")
     FREEPIK_COM_LINK = (By.XPATH, "(//section//li)[1]/a")
+    FREEPIK_COM_LINK_SECTION = (By.XPATH, "(//section//li)[1]")

--- a/pages/used_resources_page.py
+++ b/pages/used_resources_page.py
@@ -43,6 +43,14 @@ class UsedResourcesPage(BasePage):
     def check_visibility_of_links_section_on_used_resources_page(self):
         return self.element_is_visible(self.locators.LINKS_SECTION)
 
+    @allure.step('Check if the section with the freepik.com link is present in DOM')
+    def check_presence_of_freepik_com_link_section(self):
+        return self.element_is_present(self.locators.FREEPIK_COM_LINK_SECTION)
+
+    @allure.step('Check if the section with the freepik.com link is visible on the page')
+    def check_visibility_of_freepik_com_link_section(self):
+        return self.element_is_visible(self.locators.FREEPIK_COM_LINK_SECTION)
+
     @allure.step('Check the freepik.com link is present in DOM')
     def check_freepik_com_link_presence(self):
         return self.element_is_present(self.locators.FREEPIK_COM_LINK)

--- a/tests/used_resources_page_test.py
+++ b/tests/used_resources_page_test.py
@@ -48,9 +48,15 @@ class TestUsedResourcesPage:
             assert links_section_presence is not None, "The section with links is absent in DOM"
             assert links_section_visibility, "The section with links is invisible on the page"
 
-        @allure.title("Verify presence and visibility of the section with freepik.com link on the page")
+        @allure.title("Verify presence and visibility of the section with the freepik.com link on the page")
         def test_ur_01_04_verify_section_of_freepik_com_link(self, driver, auto_test_user_authorized):
-            pass
+            page = UsedResourcesPage(driver)
+            page.open_used_resources_page()
+            print(driver.current_url)
+            section_presence = page.check_presence_of_freepik_com_link_section()
+            section_visibility = page.check_visibility_of_freepik_com_link_section()
+            assert section_presence is not None, "The section with the freepik.com link is absent"
+            assert section_visibility, "The section with the freepik.com link is invisible"
 
         @allure.title("Verify presence, visibility, clickability, href, status code of the freepik.com link")
         def test_ur_01_05_verify_freepik_com_link(self, driver, auto_test_user_authorized):


### PR DESCRIPTION
add test_ur_01.04 Verify presence and visibility of the section with the freepik.com link on the page
update used_resources_page_test.py, used_resources_page.py, used_resources_page_locators.py
#39