### PR TITLE
Issue_35_Footer_JETBRAINS_link's_image

### DIFF
--- a/pages/footer_page.py
+++ b/pages/footer_page.py
@@ -124,8 +124,12 @@ class FooterPage(BasePage):
     def get_visible_height_of_epam_image(self):
         return self.element_is_visible(self.locators.EPAM_IMAGE).get_attribute('height')
 
-    @allure.step('Check the Jetbrains link is present and visible in Footer')
-    def check_jetbrains_link_presence_and_visibility(self):
+    @allure.step('Check the Jetbrains link is present in Footer')
+    def check_jetbrains_link_presence(self):
+        return self.element_is_present(self.locators.JETBRAINS_LINK)
+
+    @allure.step('Check the Jetbrains link is visible in Footer')
+    def check_jetbrains_link_visibility(self):
         return self.element_is_visible(self.locators.JETBRAINS_LINK)
 
     @allure.step('Check the Jetbrains link is clickable in Footer')

--- a/tests/footer_test.py
+++ b/tests/footer_test.py
@@ -64,33 +64,27 @@ class TestFooter:
             link_status_code = requests.head(link_href).status_code
             assert link_presence is not None, f"The {link_href} link is absent"
             assert link_visibility, f"The {link_href} link is invisible"
-            assert link_clickability is not None, f"The {link_href} link is unclickable"
+            assert link_clickability, f"The {link_href} link is unclickable"
             assert link_href == FooterData.footer_links_href["epam_link_href"], \
                 f"The attribute 'href' of the {link_href} link does not match the expected value"
             assert link_status_code == FooterData.footer_links_status_codes["epam_link_status_code"], \
                 f"The {link_href} link status code does not match the expected value"
 
-        @allure.title("Verify presence, visibility and accuracy of the JETBRAINS link and link's image in Footer")
+        @allure.title("Verify presence, visibility, clickability, href, status code of the JETBRAINS link in Footer")
         def test_fp_01_05_verify_jetbrains_link(self, driver, main_page_open):
             page = FooterPage(driver)
-            link_presence_and_visibility = page.check_jetbrains_link_presence_and_visibility()
+            link_presence = page.check_jetbrains_link_presence()
+            link_visibility = page.check_jetbrains_link_visibility()
             link_clickability = page.check_jetbrains_link_clickability()
             link_href = page.get_jetbrains_link_href()
             link_status_code = requests.head(link_href).status_code
-            link_image_visibility = page.check_jetbrains_image_visibility()
-            link_image_src = page.get_jetbrains_image_src()
-            link_image_alt = page.get_jetbrains_image_alt()
-            assert link_presence_and_visibility is not None, "The JETBRAINS link is absent or invisible"
-            assert link_clickability is not None, "The JETBRAINS link is unclickable"
+            assert link_presence is not None, f"The {link_href} link is absent"
+            assert link_visibility, f"The {link_href} link is invisible"
+            assert link_clickability, f"The {link_href} link is unclickable"
             assert link_href == FooterData.footer_links_href["jetbrains_link_href"], \
-                "The attribute 'href' of the JETBRAINS link does not match the expected value"
+                f"The attribute 'href' of the {link_href} link does not match the expected value"
             assert link_status_code == FooterData.footer_links_status_codes["jetbrains_link_status_code"], \
-                "The JETBRAINS link status code does not match the expected value"
-            assert link_image_visibility is not None, "The JETBRAINS link image is absent or invisible"
-            assert link_image_src == FooterData.footer_images_src["jetbrains_img_src"], \
-                "The JETBRAINS link image is unaccurate"
-            assert link_image_alt == FooterData.footer_images_alt["jetbrains_img_alt"], \
-                "The JETBRAINS link image is unaccurate"
+                f"The {link_href} link status code does not match the expected value"
 
         @allure.title("Verify presence, visibility and accuracy of the REG.RU link and link's image in Footer")
         def test_fp_01_06_verify_reg_link(self, driver, main_page_open):
@@ -311,3 +305,18 @@ class TestFooter:
                 f"The image width in the {link_href} link in Footer has not changed due to resizing"
             assert image_height == image_height_new, \
                 f"The image height in the {link_href} link in Footer has changed due to resizing"
+
+        @allure.title("Verify presence, visibility and accuracy of the JETBRAINS link's image in Footer")
+        def test_fp_04_07_verify_jetbrains_link_image(self, driver, main_page_open):
+            page = FooterPage(driver)
+            link_image_presence = page.check_jetbrains_image_presence()
+            link_image_visibility = page.check_jetbrains_image_visibility()
+            link_image_src = page.get_jetbrains_image_src()
+            link_image_alt = page.get_jetbrains_image_alt()
+            assert link_image_presence is not None, "The image in the JETBRAINS link is absent"
+            assert link_image_visibility, "The image in the JETBRAINS link is invisible"
+            assert link_image_src == FooterData.footer_images_src["jetbrains_img_src"], \
+                "The 'src' attribute value of the JETBRAINS link image is unaccurate"
+            assert link_image_alt, "The 'alt' attribute value of the JETBRAINS link image is empty"
+            assert link_image_alt == FooterData.footer_images_alt["jetbrains_img_alt"], \
+                "The JETBRAINS link image is unaccurate"


### PR DESCRIPTION
add test_fp_04.07 Verify presence, visibility and accuracy of the JETBRAINS link's image in Footer
ref test_fp_01.05,
update footer_test.py, footer_page.py
#35 