### PR TITLE
Issue_35_Footer_JETBRAINS_link's_image

### DIFF
--- a/pages/footer_page.py
+++ b/pages/footer_page.py
@@ -168,6 +168,14 @@ class FooterPage(BasePage):
     def get_jetbrains_image_alt(self):
         return self.get_image_alt(self.locators.JETBRAINS_IMAGE)
 
+    @allure.step('Get attribute "width" of the Jetbrains image in Footer')
+    def get_visible_width_of_jetbrains_image(self):
+        return self.element_is_visible(self.locators.JETBRAINS_IMAGE).get_attribute('width')
+
+    @allure.step('Get attribute "height" of the Jetbrains image in Footer')
+    def get_visible_height_of_jetbrains_image(self):
+        return self.element_is_visible(self.locators.JETBRAINS_IMAGE).get_attribute('height')
+
     @allure.step('Check the REG.RU link is present and visible in Footer')
     def check_reg_link_presence_and_visibility(self):
         return self.element_is_visible(self.locators.REG_LINK)

--- a/tests/footer_test.py
+++ b/tests/footer_test.py
@@ -320,3 +320,16 @@ class TestFooter:
             assert link_image_alt, "The 'alt' attribute value of the JETBRAINS link image is empty"
             assert link_image_alt == FooterData.footer_images_alt["jetbrains_img_alt"], \
                 "The JETBRAINS link image is unaccurate"
+
+        @allure.title("Verify visible sizes of the JETBRAINS link's image in Footer")
+        def test_fp_04_08_verify_visible_sizes_of_jetbrains_link_image(self, driver, main_page_open):
+            page = FooterPage(driver)
+            link_href = page.get_jetbrains_link_href()
+            image_width = page.get_visible_width_of_jetbrains_image()
+            image_height = page.get_visible_height_of_jetbrains_image()
+            print(f"The current visible sizes of the picture in the {link_href} link are: "
+                  f"{image_width}x{image_height} px")
+            assert image_width != 0, \
+                f"The image in the {link_href} link in Footer is invisible, a reason: image width = 0"
+            assert image_height != 0, \
+                f"The image in the {link_href} link in Footer is invisible, a reason: image height = 0"


### PR DESCRIPTION
add test_fp_04.08 Verify visible sizes of the JETBRAINS link's image in Footer
update footer_test.py, footer_page.py
#35 