### PR TITLE
Issue_189_SPECIALISTS_PAGE_cards_text

### DIFF
--- a/locators/specialists_page_locators.py
+++ b/locators/specialists_page_locators.py
@@ -11,3 +11,5 @@ class SpecialistsPageLocators:
     PAGE_GRID_CONTENT = (By.XPATH, "//div[contains(@class, 'rounded-lg')]")
     PAGE_TEXT = (By.XPATH, "//div[contains(@class, 'text-lg')]")
     PAGE_TITLE = (By.TAG_NAME, "h2")
+    SPECIALIST_NAMES = (By.XPATH, "//div[contains(@class, 'mb-4')]")
+    SPECIALIST_PROFESSION_SECTIONS = (By.XPATH, "//div[@class='font-openSans']")

--- a/pages/specialists_page.py
+++ b/pages/specialists_page.py
@@ -138,3 +138,27 @@ class SpecialistsPage(BasePage):
         card_text_sections = self.get_list_of_text_sections_in_cards()
         for text_section in card_text_sections:
             return text_section.is_displayed()
+
+    @allure.step("Get the list of names in specialist cards on the page")
+    def get_list_of_specialist_names_in_cards(self):
+        specialist_names = self.elements_are_present(self.locators.SPECIALIST_NAMES)
+        print(f"Amount of specialist names in cards is: {len(specialist_names)}")
+        return specialist_names
+
+    @allure.step("Check the name in each specialist card is visible on the page")
+    def check_presence_and_visibility_of_names_in_specialist_cards(self):
+        specialist_names = self.get_list_of_specialist_names_in_cards()
+        for specialist_name in specialist_names:
+            return specialist_name.is_displayed()
+
+    @allure.step("Get the list of sections with profession in specialist cards on the page")
+    def get_list_of_specialist_professions_in_cards(self):
+        specialist_profession_sections = self.elements_are_present(self.locators.SPECIALIST_PROFESSION_SECTIONS)
+        print(f"Amount of specialist profession descriptions in cards is: {len(specialist_profession_sections)}")
+        return specialist_profession_sections
+
+    @allure.step("Check the section with profession in each specialist card is visible on the page")
+    def check_presence_and_visibility_of_professions_in_specialist_cards(self):
+        specialist_profession_sections = self.get_list_of_specialist_professions_in_cards()
+        for specialist_profession_section in specialist_profession_sections:
+            return specialist_profession_section.is_displayed()

--- a/tests/specialists_page_test.py
+++ b/tests/specialists_page_test.py
@@ -91,8 +91,13 @@ class TestSpecialistsPage:
 
     class TestSpecialistCardsText:
 
-        @allure.title("Verify presence and visibility of text sections in specialist cards in the grid")
-        def test_sp_03_01_verify_text_sections_in_cards_are_present_and_visible(self, driver, specialists_page_open):
+        @allure.title("""Verify presence and visibility of text sections (including names and professions) 
+         in specialist cards in the grid""")
+        def test_sp_03_01_verify_text_in_cards_is_present_and_visible(self, driver, specialists_page_open):
             page = SpecialistsPage(driver)
-            text_sections_visibility = page.check_presence_and_visibility_of_text_sections_in_specialist_cards()
-            assert text_sections_visibility, "Sections with text in specialist cards are invisible in the grid"
+            text_sections = page.check_presence_and_visibility_of_text_sections_in_specialist_cards()
+            specialist_names = page.check_presence_and_visibility_of_names_in_specialist_cards()
+            specialist_professions = page.check_presence_and_visibility_of_professions_in_specialist_cards()
+            assert text_sections, "Sections with text in specialist cards are invisible in the grid"
+            assert specialist_names, "Names in specialist cards are invisible in the grid"
+            assert specialist_professions, "Professions in specialist cards are invisible in the grid"


### PR DESCRIPTION
ref test_sp_03.01 Verify presence and visibility of text sections (including names and professions) in specialist cards in the grid
update specialists_page_test.py, specialists_page.py, specialists_page_locators.py
#189 