### PR TITLE
Issue_39_USED_RESOURCES_PAGE_icons_in_sections

### DIFF
--- a/locators/used_resources_page_locators.py
+++ b/locators/used_resources_page_locators.py
@@ -15,6 +15,7 @@ class UsedResourcesPageLocators:
     PLANTS_LINK = (By.XPATH, "(//section//li)[2]/a")
     PLANTS_LINK_SECTION = (By.XPATH, "(//section//li)[2]")
     PLANTS_SECTION_ICON = (By.XPATH, "(//*[name()='svg'][@class])[2]")
+    SECTION_ICONS = (By.XPATH, "(//*[name()='svg'][@class])")
 
 
 class RelatedPagesElementsLocators:

--- a/pages/used_resources_page.py
+++ b/pages/used_resources_page.py
@@ -161,14 +161,6 @@ class UsedResourcesPage(BasePage):
     def get_icon_xmlns_in_plants_section(self):
         return self.get_icon_xmlns(self.locators.PLANTS_SECTION_ICON)
 
-    @allure.step("Get attribute 'width' of the icon in 'Plants' link's section")
-    def get_width_of_icon_in_plants_section(self):
-        return self.get_icon_width(self.locators.PLANTS_SECTION_ICON)
-
-    @allure.step("Get attribute 'height' of the icon in 'Plants' link's section")
-    def get_height_of_icon_in_plants_section(self):
-        return self.get_icon_height(self.locators.PLANTS_SECTION_ICON)
-
     @allure.step("Check if the section with the 'Flora' link is present in DOM")
     def check_presence_of_flora_link_section(self):
         return self.element_is_present(self.locators.FLORA_LINK_SECTION)
@@ -217,10 +209,45 @@ class UsedResourcesPage(BasePage):
     def get_icon_xmlns_in_flora_section(self):
         return self.get_icon_xmlns(self.locators.FLORA_SECTION_ICON)
 
-    @allure.step("Get attribute 'width' of the icon in 'Flora' link's section")
-    def get_width_of_icon_in_flora_section(self):
-        return self.get_icon_width(self.locators.FLORA_SECTION_ICON)
+    # Checks of icons in sections with links
+    @allure.step("Get the list of images in specialist cards on the page")
+    def get_list_of_icons(self):
+        icons = self.elements_are_present(self.locators.SECTION_ICONS)
+        print(f"\nAmount of icons is: {len(icons)}")
+        return icons
 
-    @allure.step("Get attribute 'height' of the icon in 'Flora' link's section")
-    def get_height_of_icon_in_flora_section(self):
-        return self.get_icon_height(self.locators.FLORA_SECTION_ICON)
+    @allure.step("Get the list of attribute 'src' values of images in specialist cards on the page")
+    def get_icons_sizes(self):
+        icons = self.get_list_of_icons()
+        # icons_sizes = [icon.get_attribute('size') for icon in icons]
+        icons_sizes = [icon.size for icon in icons]
+        print(f"The sizes of icons in sections are:", *icons_sizes, sep='\n')
+        return icons_sizes
+
+    @allure.step("""Check changes of icons sizes after resizing""")
+    def check_size_changes_of_icons(self):
+        icons = self.get_list_of_icons()
+        icons_sizes_before = [icon.size for icon in icons]
+        self.driver.set_window_size(1200, 800)
+        icons_sizes_after = [icon.size for icon in icons]
+        print("The results of checking changes of icon sizes after resizing are:")
+        changed, lost, unchanged = 0, 0, 0
+        for i in range(len(icons_sizes_after)):
+            if icons_sizes_before[i] != icons_sizes_after[i]:
+                changed += 1
+                if icons_sizes_after[i] == {'height': 0, 'width': 0}:
+                    lost += 1
+                    print(f"\n   The icon #{i + 1} has become invisible because has sizes that changed: "
+                          f"\nfrom {icons_sizes_before[i]} before resizing \nto {icons_sizes_after[i]} after resizing")
+                else:
+                    print(f"\n   The icon #{i + 1} has sizes that changed: \nfrom {icons_sizes_before[i]} before "
+                          f"resizing \nto {icons_sizes_after[i]} after resizing")
+            else:
+                unchanged += 1
+                print(
+                    f"\n   The icon #{i + 1} has sizes that remain: \nthe same {icons_sizes_before[i]} before resizing "
+                    f"\nand {icons_sizes_after[i]} after resizing")
+        print(f"\nSummary of icon size checks\n   Amount of icons with changed sizes after resizing is: {changed}, "
+              f"\nincluding icons that have become invisible on the page: {lost}")
+        print(f"   Amount of icons with unchanged sizes after resizing is: {unchanged}")
+        return changed, lost, unchanged

--- a/tests/header_test.py
+++ b/tests/header_test.py
@@ -1,5 +1,5 @@
 """Auto tests for verifying web elements in the Header of the site"""
-import time
+
 
 import allure
 from pages.header_page import HeaderPage
@@ -141,7 +141,8 @@ class TestHeaderPage:
                 assert links_href, "Links href are empty"
                 assert links_href == HeaderData.links_href["section 2 links href"], \
                     "The attribute 'href' of the links do not match the valid values"
-                assert all(link_status_code == HeaderData.links_status_code for link_status_code in links_status_code), \
+                assert all(link_status_code ==
+                           HeaderData.links_status_code for link_status_code in links_status_code), \
                     "The status code of the links do not match the valid value"
 
             @allure.title("""Verify if the 'About' and the 'Telegram' links in the Section 2 

--- a/tests/used_resources_page_test.py
+++ b/tests/used_resources_page_test.py
@@ -22,7 +22,8 @@ class TestUsedResourcesPage:
             page_title_text = page.get_used_resources_page_title_content()
             assert page_title_presence is not None, "The title is absent in DOM"
             assert page_title_visibility, "The title is invisible on the page"
-            assert page_title_text in UsedResourcesPageData.used_resources_page_elements_content["page_title_content"], \
+            assert (page_title_text
+                    in UsedResourcesPageData.used_resources_page_elements_content["page_title_content"]), \
                 "The title content does not match the any of the valid option"
 
         @allure.title("Verify presence, visibility and content accuracy of the text on the page")
@@ -34,7 +35,8 @@ class TestUsedResourcesPage:
             page_text_content = page.get_text_content_on_the_used_resources_page()
             assert page_text_presence is not None, "The text is absent in DOM"
             assert page_text_visibility, "The text is invisible on the page"
-            assert page_text_content in UsedResourcesPageData.used_resources_page_elements_content["page_text_content"], \
+            assert (page_text_content
+                    in UsedResourcesPageData.used_resources_page_elements_content["page_text_content"]), \
                 "The text content does not match the any of the valid option"
 
         @allure.title("Verify presence and visibility of the section with links on the page")
@@ -103,16 +105,6 @@ class TestUsedResourcesPage:
             assert icon_xmlns == UsedResourcesPageData.icons_xmlns["icons_xmlns_on_used_resources_page"], \
                 "The 'xmlns' attribute value of the icon in the freepik.com link's section is unaccurate"
 
-        @allure.title("Verify sizes of the icon in the freepik.com link's section")
-        def test_ur_01_08_verify_sizes_of_icon_in_freepik_com_section(self, driver, auto_test_user_authorized):
-            page = UsedResourcesPage(driver)
-            page.open_used_resources_page()
-            icon_width = page.get_width_of_icon_in_freepik_com_section()
-            icon_height = page.get_height_of_icon_in_freepik_com_section()
-            # print(f"The icon sizes are: {icon_width}x{icon_height} px")
-            assert icon_width != 0, "The icon in the freepik.com link's section hasn't width"
-            assert icon_height != 0, "The icon in the freepik.com link's section hasn't height"
-
         @allure.title("Verify presence and visibility of the section with the 'Plants' link on the page")
         def test_ur_01_09_verify_section_of_plants_link(self, driver, auto_test_user_authorized):
             page = UsedResourcesPage(driver)
@@ -169,16 +161,6 @@ class TestUsedResourcesPage:
             assert icon_xmlns, "The 'xmlns' attribute value of the icon in the 'Plants' link's section is empty"
             assert icon_xmlns == UsedResourcesPageData.icons_xmlns["icons_xmlns_on_used_resources_page"], \
                 "The 'xmlns' attribute value of the icon in the 'Plants' link's section is unaccurate"
-
-        @allure.title("Verify sizes of the icon in the 'Plants' link's section")
-        def test_ur_01_13_verify_sizes_of_icon_in_plants_section(self, driver, auto_test_user_authorized):
-            page = UsedResourcesPage(driver)
-            page.open_used_resources_page()
-            icon_width = page.get_width_of_icon_in_plants_section()
-            icon_height = page.get_height_of_icon_in_plants_section()
-            # print(f"The icon sizes are: {icon_width}x{icon_height} px")
-            assert icon_width != 0, "The icon in the 'Plants' link's section hasn't width"
-            assert icon_height != 0, "The icon in the 'Plants' link's section hasn't height"
 
         @allure.title("Verify presence and visibility of the section with the 'Flora' link on the page")
         def test_ur_01_14_verify_section_of_flora_link(self, driver, auto_test_user_authorized):
@@ -237,12 +219,13 @@ class TestUsedResourcesPage:
             assert icon_xmlns == UsedResourcesPageData.icons_xmlns["icons_xmlns_on_used_resources_page"], \
                 "The 'xmlns' attribute value of the icon in the 'Flora' link's section is unaccurate"
 
-        @allure.title("Verify sizes of the icon in the 'Flora' link's section")
-        def test_ur_01_18_verify_sizes_of_icon_in_flora_section(self, driver, auto_test_user_authorized):
-            page = UsedResourcesPage(driver)
-            page.open_used_resources_page()
-            icon_width = page.get_width_of_icon_in_flora_section()
-            icon_height = page.get_height_of_icon_in_flora_section()
-            # print(f"The icon sizes are: {icon_width}x{icon_height} px")
-            assert icon_width != 0, "The icon in the 'Flora' link's section hasn't width"
-            assert icon_height != 0, "The icon in the 'Flora' link's section hasn't height"
+        class TestUsedResourcesPageForAuthorizedUserIcons:
+
+            @allure.title("Verify sizes of icons in the sections")
+            def test_ur_02_02_verify_icons_sizes(self, driver, auto_test_user_authorized):
+                page = UsedResourcesPage(driver)
+                page.open_used_resources_page()
+                icons_size = page.get_icons_sizes()
+                icons_size_changes = page.check_size_changes_of_icons()
+                assert icons_size != 0, "The icons in the sections hasn't sizes"
+                assert icons_size_changes, "Checks of changes in icon sizes have not carried out"


### PR DESCRIPTION
add test_ur_02.02 Verify sizes of icons in the sections
instead of deleted, due to the unification of checks
delete test_ur_01.08, _01.13, _01.18,
update used_resources_page_test.py, used_resources_page.py, used_resources_page_locators.py, header_test.py
#39 