### PR TITLE
Issue_39_USED_RESOURCES_PAGE_links_in_sections

### DIFF
--- a/locators/used_resources_page_locators.py
+++ b/locators/used_resources_page_locators.py
@@ -17,12 +17,3 @@ class UsedResourcesPageLocators:
     PLANTS_SECTION_ICON = (By.XPATH, "(//*[name()='svg'][@class])[2]")
     SECTION_ICONS = (By.XPATH, "(//*[name()='svg'][@class])")
     SECTION_LINKS = (By.XPATH, "//section//a")
-
-
-class RelatedPagesElementsLocators:
-    # on 'Flora' web page
-    FLORA_TEXT = (By.TAG_NAME, "h2")
-    # on freepik.com web page
-    FREEPIK_COM_TEXT = (By.XPATH, "//main//h1")
-    # on 'Plants' web page
-    PLANTS_TEXT = (By.XPATH, "//h1/span")

--- a/pages/used_resources_page.py
+++ b/pages/used_resources_page.py
@@ -3,12 +3,11 @@ import allure
 import requests
 from pages.base_page import BasePage
 from test_data.links import MainPageLinks
-from locators.used_resources_page_locators import UsedResourcesPageLocators, RelatedPagesElementsLocators
+from locators.used_resources_page_locators import UsedResourcesPageLocators
 
 
 class UsedResourcesPage(BasePage):
     locators = UsedResourcesPageLocators
-    locators1 = RelatedPagesElementsLocators
 
     @allure.step("Open the 'Used resources' page")
     def open_used_resources_page(self):
@@ -54,14 +53,6 @@ class UsedResourcesPage(BasePage):
     def check_visibility_of_freepik_com_link_section(self):
         return self.element_is_visible(self.locators.FREEPIK_COM_LINK_SECTION)
 
-    @allure.step("Click on the freepik.com link and thereby open the corresponding web page in a new tab")
-    def click_freepik_com_link(self):
-        self.element_is_present_and_clickable(self.locators.FREEPIK_COM_LINK).click()
-
-    @allure.step("Get text of the element on the freepik.com page")
-    def get_element_text_on_opened_freepik_com_tab(self):
-        return self.get_text(self.locators1.FREEPIK_COM_TEXT)
-
     @allure.step("Get content of the text in the freepik.com link")
     def get_text_in_freepik_com_link(self):
         return self.element_is_present(self.locators.FREEPIK_COM_LINK).text
@@ -73,14 +64,6 @@ class UsedResourcesPage(BasePage):
     @allure.step("Check if the section with the 'Plants' link is visible on the page")
     def check_visibility_of_plants_link_section(self):
         return self.element_is_visible(self.locators.PLANTS_LINK_SECTION)
-
-    @allure.step("Click on the 'Plants' link and thereby open the corresponding web page in a new tab")
-    def click_plants_link(self):
-        self.element_is_present_and_clickable(self.locators.PLANTS_LINK).click()
-
-    @allure.step("Get text of the element on the 'Plants' page")
-    def get_element_text_on_opened_plants_tab(self):
-        return self.get_text(self.locators1.PLANTS_TEXT)
 
     @allure.step("Get content of the text in the 'Plants' link")
     def get_text_in_plants_link(self):
@@ -94,19 +77,11 @@ class UsedResourcesPage(BasePage):
     def check_visibility_of_flora_link_section(self):
         return self.element_is_visible(self.locators.FLORA_LINK_SECTION)
 
-    @allure.step("Click on the 'Flora' link and thereby open the corresponding web page in a new tab")
-    def click_flora_link(self):
-        self.element_is_present_and_clickable(self.locators.FLORA_LINK).click()
-
-    @allure.step("Get text of the element on the 'Flora' page")
-    def get_element_text_on_opened_flora_tab(self):
-        return self.get_text(self.locators1.FLORA_TEXT)
-
     @allure.step("Get content of the text in the 'Flora' link")
     def get_text_in_flora_link(self):
         return self.element_is_present(self.locators.FLORA_LINK).text
 
-    # Checks of links in the sections
+    # Checking links in the sections
     @allure.step("Get the list of links in the sections on the page")
     def get_list_of_links(self):
         links = self.elements_are_present(self.locators.SECTION_LINKS)
@@ -133,7 +108,17 @@ class UsedResourcesPage(BasePage):
         # print(f"Links status codes in the sections are:", *links_status_codes, sep='\n')
         return links_status_codes
 
-    # Checks of icons in the sections with links
+    @allure.step("Click on links in the sections and thereby open corresponding web pages on new tabs")
+    def click_on_links(self):
+        new_tabs = [link.click() for link in self.get_list_of_links()]
+        new_tabs_url = []
+        for i in range(1, len(new_tabs) + 1):
+            self.driver.switch_to.window(self.driver.window_handles[i])
+            new_tabs_url.append(self.driver.current_url)
+        # print('\n', *new_tabs_url, sep='\n')
+        return new_tabs_url
+
+    # Checking icons in the sections with links
     @allure.step("Get the list of icons in the sections")
     def get_list_of_icons(self):
         icons = self.elements_are_present(self.locators.SECTION_ICONS)

--- a/test_data/used_resources_page_data.py
+++ b/test_data/used_resources_page_data.py
@@ -26,11 +26,15 @@ class UsedResourcesPageData:
 
     links_status_codes = [200, 301]
 
-    # Related web pages elements text
-    used_resources_page_related_elements_text = {
-        "flora_page_text": "Gera-Untermhaus",
-        "freepik_com_start_page_text": "Create great designs, faster",
-        "plants_page_text": "Список растений, иллюстрации к которым размещены в справочнике Köhler’s Medizinal-Pflanzen"
-    }
+    # Related web pages url
+    pages_url = ["https://ru.wikipedia.org/wiki/%D0%A1%D0%BF%D0%B8%D1%81%D0%BE%D0%BA"
+                 "_%D1%80%D0%B0%D1%81%D1%82%D0%B5%D0%BD%D0%B8%D0%B9,"
+                 "_%D0%B8%D0%BB%D0%BB%D1%8E%D1%81%D1%82%D1%80%D0%B0%D1%86%D0%B8%D0%B8_%D0%BA"
+                 "_%D0%BA%D0%BE%D1%82%D0%BE%D1%80%D1%8B%D0%BC_%D1%80%D0%B0%D0%B7%D0%BC%D0%B5%D1%89%D0%B5%D0%BD%D1%8B"
+                 "_%D0%B2_%D1%81%D0%BF%D1%80%D0%B0%D0%B2%D0%BE%D1%87%D0%BD%D0%B8%D0%BA%D0%B5_K%C3%B6hler%E2%80%99s"
+                 "_Medizinal-Pflanzen",
+                 "https://www.freepik.com/",
+                 "http://caliban.mpiz-koeln.mpg.de/~stueber/thome/Alphabetical_list.html"
+                 ]
 
     icons_xmlns = "http://www.w3.org/2000/svg"

--- a/tests/used_resources_page_test.py
+++ b/tests/used_resources_page_test.py
@@ -1,7 +1,6 @@
 """Auto tests for verifying web elements on the 'Used Resources' page"""
 import allure
 from pages.used_resources_page import UsedResourcesPage
-from locators.used_resources_page_locators import UsedResourcesPageLocators
 from test_data.used_resources_page_data import UsedResourcesPageData
 
 
@@ -10,7 +9,6 @@ class TestUsedResourcesPage:
     data = UsedResourcesPageData
 
     class TestUsedResourcesPageForAuthorizedUser:
-        locators = UsedResourcesPageLocators()
 
         @allure.title("Verify presence, visibility and text accuracy of the title on the page")
         def test_ur_01_01_verify_used_resources_page_title(self, driver, auto_test_user_authorized):
@@ -65,18 +63,6 @@ class TestUsedResourcesPage:
                    UsedResourcesPageData.used_resources_page_elements_content["freepik_com_link_content"], \
                    f"The actual text of the link does not match the valid option"
 
-        @allure.title("Verify that the freepik.com link leads to the correct page after click")
-        def test_ur_01_06_verify_freepik_com_link_leads_to_the_correct_page(self, driver, auto_test_user_authorized):
-            page = UsedResourcesPage(driver)
-            page.open_used_resources_page()
-            page.click_freepik_com_link()
-            page.switch_to_new_window()
-            text_on_opened_tab = page.get_element_text_on_opened_freepik_com_tab()
-            assert text_on_opened_tab == \
-                   UsedResourcesPageData.used_resources_page_related_elements_text["freepik_com_start_page_text"], \
-                   "The freepik.com link leads to an incorrect page after click " \
-                   "or opened page does not load correctly"
-
         @allure.title("Verify presence and visibility of the section with the 'Plants' link on the page")
         def test_ur_01_09_verify_section_of_plants_link(self, driver, auto_test_user_authorized):
             page = UsedResourcesPage(driver)
@@ -95,18 +81,6 @@ class TestUsedResourcesPage:
                    UsedResourcesPageData.used_resources_page_elements_content["plants_link_content"], \
                    f"The actual text of the link does not match the valid option"
 
-        @allure.title("Verify that the 'Plants' link leads to the correct page after click")
-        def test_ur_01_11_verify_plants_link_leads_to_the_correct_page(self, driver, auto_test_user_authorized):
-            page = UsedResourcesPage(driver)
-            page.open_used_resources_page()
-            page.click_plants_link()
-            page.switch_to_new_window()
-            text_on_opened_tab = page.get_element_text_on_opened_plants_tab()
-            assert text_on_opened_tab == \
-                   UsedResourcesPageData.used_resources_page_related_elements_text["plants_page_text"], \
-                   "The 'Plants' link leads to an incorrect page after click " \
-                   "or opened page does not load correctly"
-
         @allure.title("Verify presence and visibility of the section with the 'Flora' link on the page")
         def test_ur_01_14_verify_section_of_flora_link(self, driver, auto_test_user_authorized):
             page = UsedResourcesPage(driver)
@@ -124,18 +98,6 @@ class TestUsedResourcesPage:
             assert actual_link_text == \
                    UsedResourcesPageData.used_resources_page_elements_content["flora_link_content"], \
                    f"The actual text of the link does not match the valid option"
-
-        @allure.title("Verify that the 'Flora' link leads to the correct page after click")
-        def test_ur_01_16_verify_flora_link_leads_to_the_correct_page(self, driver, auto_test_user_authorized):
-            page = UsedResourcesPage(driver)
-            page.open_used_resources_page()
-            page.click_flora_link()
-            page.switch_to_new_window()
-            text_on_opened_tab = page.get_element_text_on_opened_flora_tab()
-            assert text_on_opened_tab == \
-                   UsedResourcesPageData.used_resources_page_related_elements_text["flora_page_text"], \
-                   "The 'Flora' link leads to an incorrect page after click " \
-                   "or opened page does not load correctly"
 
         class TestUsedResourcesPageForAuthorizedUserLinks:
             @allure.title("""Verify presence, visibility, clickability, href, status code of links in the sections""")
@@ -156,6 +118,14 @@ class TestUsedResourcesPage:
                 assert all(link_status_code in UsedResourcesPageData.links_status_codes
                            for link_status_code in links_status_codes), \
                     "Status codes of links do not match the expected values"
+
+            @allure.title("Verify that links in the sections lead to the correct pages after clicking")
+            def test_ur_03_02_verify_links_lead_to_the_correct_pages(self, driver, auto_test_user_authorized):
+                page = UsedResourcesPage(driver)
+                page.open_used_resources_page()
+                new_tabs_url = page.click_on_links()
+                assert all(new_tab_url in UsedResourcesPageData.pages_url for new_tab_url in new_tabs_url), \
+                    "Links in the sections lead to incorrect pages after clicking"
 
         class TestUsedResourcesPageForAuthorizedUserIcons:
             @allure.title("Verify presence, visibility and attributes of icons in the sections")


### PR DESCRIPTION
add test_ur_03.02 Verify that links in the sections lead to the correct pages after clicking
instead of deleted, due to the unification of checkings
delete test_ur_01.06, _01.11, _01.16,
update used_resources_page_test.py, used_resources_page.py, used_resources_page_data.py, used_resources_page_locators.py
#39 