### PR TITLE
Issues_243,189_skipped_autotests

### DIFF
--- a/tests/contributors_page_test.py
+++ b/tests/contributors_page_test.py
@@ -1,9 +1,11 @@
 """Auto tests for verifying web elements on the 'Contributors' page"""
 import allure
+import pytest
 from pages.contributors_page import ContributorsPage
 from test_data.contributors_page_data import ContributorsPageData
 
 
+@pytest.mark.skip(reason="unsupported preconditions")
 @allure.epic("The Contributors Page")
 class TestContributorsPage:
     class TestContributorsPageStructure:

--- a/tests/specialists_page_test.py
+++ b/tests/specialists_page_test.py
@@ -1,10 +1,12 @@
 """Auto tests for verifying web elements on the 'Specialists' page"""
 import allure
+import pytest
 from pages.specialists_page import SpecialistsPage
 from test_data.specialists_page_data import SpecialistsPageData
 from test_data.start_unauthorized_page_data import StartUnauthorizedPageData
 
 
+@pytest.mark.skip(reason="unsupported preconditions")
 @allure.epic("Test Specialists Page")
 class TestSpecialistsPage:
     class TestSpecialistsPageStructure:


### PR DESCRIPTION
skip autotests, the reason is 'unsupported preconditions' (the 'Specialists' and 'Contributors' pages are unavailable)
update contributors_page_test.py, specialists_page_test.py
#243  
#189
