### PR TITLE
Issue_433_EXERCISES_WORDS_RU_PAGE_text 

### DIFF
--- a/test_data/exercises_ru_words_page_data.py
+++ b/test_data/exercises_ru_words_page_data.py
@@ -3,3 +3,4 @@
 
 class ExercisesRuWordsPageData:
     tab_title = ["Речевые упражнения (готовы для занятий) | BrainUp", "Speech exercises | BrainUp"]
+    tab_title_ru = "Речевые упражнения (готовы для занятий) | BrainUp"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,8 +47,20 @@ def description_page_open(driver):
 
 @pytest.fixture()
 @allure.step(f'Open page: {ExercisesUrls.URL_EXERCISES_RU_WORDS_PAGE}')
-def exercises_ru_words_page_open(driver, auto_test_user_authorized):
+def exercises_ru_words_page_open1(driver, auto_test_user_authorized):
     page = BasePage(driver)
+    page.element_is_present_and_clickable(HeaderUnauthorizedLocators.RU_BUTTON).click()
+    page.element_is_present_and_clickable(GroupsPageLocators.PAGE_LINK2).click()
+    time.sleep(3)
+
+@pytest.fixture()
+@allure.step(f'Open page: {ExercisesUrls.URL_EXERCISES_RU_WORDS_PAGE}')
+def exercises_ru_words_page_open(driver, main_page_open):
+    page = BasePage(driver)
+    page.element_is_present_and_clickable(MainPageLocators.LOGIN_BUTTON).click()
+    page.element_is_visible(LoginPageLocators.INPUT_LOGIN).send_keys(os.environ["LOGIN"])
+    page.element_is_visible(LoginPageLocators.INPUT_PASSWORD).send_keys(os.environ["PASSWORD"])
+    page.element_is_present_and_clickable(LoginPageLocators.SIGN_IN_BUTTON).click()
     page.element_is_present_and_clickable(HeaderUnauthorizedLocators.RU_BUTTON).click()
     page.element_is_present_and_clickable(GroupsPageLocators.PAGE_LINK2).click()
     time.sleep(3)

--- a/tests/exercises_ru_words_page_test.py
+++ b/tests/exercises_ru_words_page_test.py
@@ -66,5 +66,5 @@ class TestExercisesRuWordsPage:
             page = ExercisesRuWordsPage(driver)
             tab_title_value = page.get_value_of_tab_title()
             assert tab_title_value, "The title value of the tab is empty"
-            assert tab_title_value in ExercisesRuWordsPageData.tab_title, \
+            assert tab_title_value == ExercisesRuWordsPageData.tab_title_ru, \
                 "The title on the tab doesn't match the valid value"


### PR DESCRIPTION
ref test_erw_02.01 Verivy the tab title on the 'ru' local
update exercises_ru_words_page_test.py, exercises_ru_words_page_data.py, conftest.py
#433 